### PR TITLE
Kotlin dependency lock issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
     id 'nebula.plugin-plugin' version '8.0.0'
-    id 'nebula.kotlin' version '1.2.61'
+    id 'nebula.kotlin' version '1.2.70'
 }
 
 description 'Provides the Kotlin plugin via the Gradle plugin portal and allows Kotlin library versions to be omitted'

--- a/src/main/kotlin/netflix/nebula/NebulaKotlinPlugin.kt
+++ b/src/main/kotlin/netflix/nebula/NebulaKotlinPlugin.kt
@@ -15,7 +15,8 @@ import java.util.*
 
 class NebulaKotlinPlugin : Plugin<Project> {
 
-    private val AFFECTED_KOTLIN_VERSION = "1.2.70"
+    //TODO: keep track of https://youtrack.jetbrains.com/issue/KT-26834 and see if this gets fixed in 1.2.72 as assigned
+    private val AFFECTED_KOTLIN_VERSIONS = arrayOf("1.2.70", "1.2.71")
 
     companion object {
         @JvmStatic
@@ -54,7 +55,7 @@ class NebulaKotlinPlugin : Plugin<Project> {
             }
 
             configurations.all({ configuration ->
-                if(kotlinVersion == AFFECTED_KOTLIN_VERSION && configuration.attributes.contains(KotlinPlatformType.attribute)) {
+                if(kotlinVersion in AFFECTED_KOTLIN_VERSIONS && configuration.attributes.contains(KotlinPlatformType.attribute)) {
                     configuration.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
                 }
 

--- a/src/main/kotlin/netflix/nebula/NebulaKotlinPlugin.kt
+++ b/src/main/kotlin/netflix/nebula/NebulaKotlinPlugin.kt
@@ -3,14 +3,20 @@ package netflix.nebula
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.plugins.JavaPluginConvention
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.FileNotFoundException
 import java.util.*
 
 class NebulaKotlinPlugin : Plugin<Project> {
+
+    private val AFFECTED_KOTLIN_VERSION = "1.2.70"
+
     companion object {
         @JvmStatic
         fun loadKotlinVersion(): String {
@@ -30,7 +36,7 @@ class NebulaKotlinPlugin : Plugin<Project> {
             plugins.apply(KotlinPlatformJvmPlugin::class.java)
 
             val kotlinVersion = loadKotlinVersion()
-            
+
             afterEvaluate {
                 val kotlinOptions = tasks.filter { it is KotlinCompile }.map { (it as KotlinCompile).kotlinOptions }
                 val sourceCompatibility = convention.getPlugin(JavaPluginConvention::class.java).sourceCompatibility
@@ -48,6 +54,10 @@ class NebulaKotlinPlugin : Plugin<Project> {
             }
 
             configurations.all({ configuration ->
+                if(kotlinVersion == AFFECTED_KOTLIN_VERSION && configuration.attributes.contains(KotlinPlatformType.attribute)) {
+                    configuration.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
+                }
+
                 configuration.resolutionStrategy.eachDependency { details ->
                     val requested = details.requested
                     if (requested.group.equals("org.jetbrains.kotlin") && requested.version.isNullOrEmpty()) {

--- a/src/test/groovy/netflix/nebula/NebulaKotlinPluginSpec.groovy
+++ b/src/test/groovy/netflix/nebula/NebulaKotlinPluginSpec.groovy
@@ -93,12 +93,12 @@ class NebulaKotlinPluginIntegrationSpec extends IntegrationSpec {
         buildscript {
             repositories {
                 maven {
-                  url "https://plugins.gradle.org/m2/"
+                    jcenter()
+                    url "https://plugins.gradle.org/m2/"
                 }
             }
             dependencies {
-                 classpath 'com.netflix.nebula:nebula-kotlin-plugin:1.2.70'
-                 classpath "com.netflix.nebula:gradle-dependency-lock-plugin:6.1.1"
+                classpath "com.netflix.nebula:gradle-dependency-lock-plugin:6.1.1"
             }
         }
 
@@ -106,34 +106,24 @@ class NebulaKotlinPluginIntegrationSpec extends IntegrationSpec {
             mavenCentral()
         }
         
+        allprojects {
+            apply plugin: 'nebula.dependency-lock'
+        }
+        
         subprojects {
-                apply plugin: 'nebula.dependency-lock'
+            apply plugin: 'nebula.kotlin'
+            apply plugin: 'kotlin-spring'
+            
+            kotlin {
+                experimental {
+                    coroutines 'enable'
+                }
+            }
         }
 
- 
         """
-        addSubproject("sub1", """
-            apply plugin: 'java'
-
-            repositories {
-                mavenCentral()
-            }
-            
-            dependencies {
-                compile project(":sub2")
-            }
-        """)
 
         addSubproject("sub2", """
-            apply plugin: 'java'
-            apply plugin: 'nebula.kotlin'
-
-            kotlin {
-                 experimental {
-                      coroutines 'enable'
-                 }
-            }
-                
             repositories {
                 mavenCentral()
             }
@@ -143,10 +133,20 @@ class NebulaKotlinPluginIntegrationSpec extends IntegrationSpec {
             }
         """)
 
+        addSubproject("sub1", """
+            apply plugin: 'groovy'
+            dependencies {
+                  compile project(":sub2")
+            }
+        """)
+
+
         when:
         runTasksSuccessfully('generateLock', 'saveLock')
 
         then:
         noExceptionThrown()
     }
+
+
 }

--- a/src/test/groovy/netflix/nebula/NebulaKotlinPluginSpec.groovy
+++ b/src/test/groovy/netflix/nebula/NebulaKotlinPluginSpec.groovy
@@ -108,36 +108,32 @@ class NebulaKotlinPluginIntegrationSpec extends IntegrationSpec {
         
         subprojects {
                 apply plugin: 'nebula.dependency-lock'
-                apply plugin: 'nebula.kotlin'
-                
-                kotlin {
-                    experimental {
-                        coroutines 'enable'
-                    }
-                }
-                
-                dependencies {
-                    testCompile 'junit:junit:latest.release'
-                }
         }
 
  
         """
         addSubproject("sub1", """
-            apply plugin: 'groovy'
+            apply plugin: 'java'
 
             repositories {
                 mavenCentral()
             }
             
             dependencies {
-                implementation group: 'com.google.guava', name: 'guava', version: '26.0-jre'
+                compile project(":sub2")
             }
         """)
 
         addSubproject("sub2", """
-            apply plugin: 'java-library'
-            
+            apply plugin: 'java'
+            apply plugin: 'nebula.kotlin'
+
+            kotlin {
+                 experimental {
+                      coroutines 'enable'
+                 }
+            }
+                
             repositories {
                 mavenCentral()
             }
@@ -148,7 +144,7 @@ class NebulaKotlinPluginIntegrationSpec extends IntegrationSpec {
         """)
 
         when:
-        runTasksSuccessfully('sub1:generateLock', 'sub1:saveLock')
+        runTasksSuccessfully('generateLock', 'saveLock')
 
         then:
         noExceptionThrown()


### PR DESCRIPTION
This is the workaround for https://youtrack.jetbrains.com/issue/KT-26834

To avoid complexity on version comparison, we will replace for `1.2.70` and `1.2.71`. The issue states that it will be fixed by `1.2.72`