### PR TITLE
Remove workaround for DependenciesMetadata - KT-26834

### DIFF
--- a/src/main/kotlin/netflix/nebula/NebulaKotlinPlugin.kt
+++ b/src/main/kotlin/netflix/nebula/NebulaKotlinPlugin.kt
@@ -3,23 +3,14 @@ package netflix.nebula
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.attributes.Attribute
 import org.gradle.api.plugins.JavaPluginConvention
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.FileNotFoundException
 import java.util.*
 
 class NebulaKotlinPlugin : Plugin<Project> {
-
-    //TODO: keep track of https://youtrack.jetbrains.com/issue/KT-26834 and see if this gets fixed in 1.2.72 as assigned
-    private val AFFECTED_KOTLIN_VERSIONS = arrayOf("1.2.70", "1.2.71")
-    private val KOTLIN_1_3_RC = "1.3.0-rc"
-    private val DEPENDENCIES_METADATA_SUFFIX = "DependenciesMetadata"
-    private val AFFECTED_CONFIGURATIONS = listOf("apiDependenciesMetadata", "apiElements", "runtimeElements")
 
     companion object {
         @JvmStatic
@@ -58,14 +49,6 @@ class NebulaKotlinPlugin : Plugin<Project> {
             }
 
             configurations.all({ configuration ->
-                if((kotlinVersion in AFFECTED_KOTLIN_VERSIONS || kotlinVersion.contains(KOTLIN_1_3_RC)) && configuration.name.endsWith(DEPENDENCIES_METADATA_SUFFIX)) {
-                    if(configuration.name in AFFECTED_CONFIGURATIONS) {
-                        configuration.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
-                    } else {
-                        configuration.setCanBeResolved(false)
-                    }
-                }
-
                 configuration.resolutionStrategy.eachDependency { details ->
                     val requested = details.requested
                     if (requested.group.equals("org.jetbrains.kotlin") && requested.version.isNullOrEmpty()) {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26834 is fixed in 1.3.x.

It should be safe to remove this workaround for future versions